### PR TITLE
[WIP] Add Pi_grammer programmer

### DIFF
--- a/sparkfun/avr/avrdude.conf
+++ b/sparkfun/avr/avrdude.conf
@@ -1110,6 +1110,13 @@ programmer
   miso  = ~8;
 ;
 
+programmer
+  id    = "linuxspi";
+  desc  = "Use the Linux SPI device in /dev/spidev*";
+  type  = "linuxspi";
+  reset = 26;
+;
+
 #
 # PART DEFINITIONS
 #

--- a/sparkfun/avr/platform.txt
+++ b/sparkfun/avr/platform.txt
@@ -92,7 +92,7 @@ recipe.preproc.macros="{compiler.path}{compiler.cpp.cmd}" {compiler.cpp.flags} {
 # ------------------------------
 tools.avrdude.path={runtime.tools.avrdude.path}
 tools.avrdude.cmd.path={path}/bin/avrdude
-tools.avrdude.config.path={path}/etc/avrdude.conf
+tools.avrdude.config.path={runtime.platform.path}/avrdude.conf
 
 tools.avrdude.network_cmd={runtime.tools.arduinoOTA.path}/bin/arduinoOTA
 

--- a/sparkfun/avr/programmers.txt
+++ b/sparkfun/avr/programmers.txt
@@ -1,0 +1,5 @@
+pi_grammer.name=PI_grammer
+pi_grammer.protocol=linuxspi
+pi_grammer.program.protocol=linuxspi
+pi_grammer.program.tool=avrdude
+pi_grammer.program.extra_params=-P /dev/spidev0.0 -b 2000000


### PR DESCRIPTION
This adds a **Tools > Programmer > Pi_grammer** menu selection after installing SparkFun AVR Boards, which allows the SPI pins of a Raspberry Pi to be used as an ISP programmer. More info [here](https://learn.sparkfun.com/tutorials/raspberry-pi-stand-alone-programmer).

#### Installation instructions:
1. Install the [hourly build of the Arduino IDE](https://www.arduino.cc/en/Main/Software#hourly). This is only a temporary requirement. Once Boards Manager support for this version of SparkFun AVR Boards is added, it will be usable with any modern version of the Arduino IDE.
1. Download the file [avrdude.zip](https://github.com/per1234/Arduino_Boards/files/2226696/avrdude.zip) (or if you prefer, build the modified AVRDUDE from source: https://github.com/per1234/avrdude/tree/linuxspi-retry)
1. Unzip the downloaded file.
1. Replace {Arduino IDE installation folder}/hardware/avr/bin/avrdude with the one from the unzipped file (required if you want to use Pi_grammer when the Arduino IDE is not run as root).
1. Download https://github.com/per1234/Arduino_Boards/archive/add-pi_grammer.zip (or clone https://github.com/per1234/Arduino_Boards.git and checkout the `add-pi_grammer` branch).
1. Unzip the downloaded file.
1. Copy the sparkfun subfolder to {sketchbook folder}/hardware. You can find the location of {sketchbook folder} in the Arduino IDE at **File > Preferences > Sketchbook location**.
1. Restart the Arduino IDE if it's running.
1. If you have previously installed SparkFun AVR Boards via Boards Manager then you need to remove it so the modified version will be used: **Tools > Board > Boards Manager**, click on "SparkFun AVR Boards", click "Remove".

#### Usage
1. Connect your Raspberry Pi to the target board:
  
  RPi GPIO | Target
  ---|---
  MOSI | MOSI
  MISO | MISO
  SCK | SCK
  3V3 | Vcc
  GND | GND
  26 | RST

  Powering a 16 MHz board at 3.3 V is out of spec and may lead to unstable operation. Connecting the RPi GPIO pins directly to a board running at 5 V can damage the RPi so you should use level shifters.

2. Enable SPI on the Raspberry Pi by following these instructions:
https://learn.sparkfun.com/tutorials/raspberry-pi-spi-and-i2c-tutorial#spi-on-pi
Note that I found the menu path to be a little different using the latest version of Raspian.
1. (In the Arduino IDE) Tools > Board > select one of the Sparkfun AVR Boards.
1. Tools > Programmer > Pi_grammer.
1. Open the sketch you want to upload to the target.
1. Sketch > Upload Using Programmer.

I've tested this working (every other time, see (1) below) with the SparkFun Digital Sandbox. I haven't tested the 16 MHz boards because I don't have level shifters to safely use my Raspberry Pi with boards running at 5 V.

To do:
- [x] 1. ~~Every other upload fails: `avrdude: linuxspi_gpio_op_wr(): Unable to open file /sys/class/gpio/gpio26/direction`.~~ (fixed by https://github.com/per1234/avrdude/commit/1b673007e0382564f50aedad8875036ca48de27c)
- [X] 2. ~~The SparkFun pi_program.sh script used for programming their products does a reset of the target between setting fuses and flashing (https://github.com/sparkfun/SparkFun_Pi_AVR_Programmer_HAT/blob/master/pi_program.sh#L29-L33). Due to (1) I have not been able to complete a Burn Bootloader to see if this is necessary. The alternative is to simply set fuses and burn bootloader in a single avrdude command. The two avrdude commands back to back have historically caused problems with the AVRISP mkII (`https://github.com/arduino/Arduino/issues/2986`) and reportedly continue to do so for the AVR Dragon (`https://github.com/arduino/ArduinoCore-avr/issues/9`).~~ (Doesn't appear to be necessary)
- [ ] 3. The change to platform.txt switches from using using the avrdude.conf bundled with Arduino's AVRDUDE tool to using the avrdude.conf bundled with SparkFun AVR Boards. As reported here: `https://github.com/sparkfun/Arduino_Boards/issues/21`, this is an outdated version of that file and so this avrdude.conf will need to be updated in order to ensure support for all newer programmers and parts. The current version of the file should be fine for any testing of the Pi_grammer programmer.
- [ ] 4. Determine whether there is official interest in adding this programmer to Arduino AVR Boards. Since the proposal comes from SparkFun, I've added the programmer to SparkFun AVR Boards but it could just as easily be done to Arduino AVR Boards instead.
- [ ] 5. The default reset pin, as set in the [kcuzner/avrdude patch](http://savannah.nongnu.org/patch/?8228) is GPIO 25. SparkFun uses 26 instead and this is the only reason the custom avrdude.conf file is necessary. With GPIO 25 as reset it's possible to use the avrdude.conf bundled with Arduino's avrdude tool and the change to platform.txt is not necessary. It seems like the change to 26 was solely due to the layout of SparkFun's custom hat, which is not likely to be used with Arduino or by general users anyway.
- [ ] 6. If this doesn't end up being accepted to Arduino AVR Boards, I think it would actually be more appropriate as a 3rd party package rather than part of SparkFun AVR Boards. This would need to wait for the retry fix to be made to avrdude, the fix to be picked up by Arduino, and Arduino to make a release of Arduino AVR Boards with the fixed AVRDUDE.

Reference:
https://github.com/arduino/Arduino/issues/7795